### PR TITLE
Fix storage options by using Amazon S3 + Fix Show.published

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link application.js

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -39,7 +39,7 @@ class Show < ApplicationRecord
   validates_inclusion_of :show_type, in: SHOW_TYPES
 
   def published?
-    published_on? && published_on <= Time.now.utc
+    self[:published] || published_on? && published_on <= Time.now.utc
   end
 
   def title

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This PR fixes the file storage options by using Amazon S3 instead of local file storage (which is not supported on Heroku).

Some adjustments on the Shows model were made to the published method as well.