### PR TITLE
Fix Seed CSV operation

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
+  config.active_job.queue_adapter = :inline
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
The database schema has significant changes, so changes to the `SeedCSV` file were made:
- Require a banner files' folder location (`banners_root`)
- Infer some of the csv file's fields from the `locales`
- Checking if a show was already seeded by checking if it's Japanese title already exists (guaranteed to be unique)
- Create the private `title_params` annd `description_params` based on the `locales`. For example: `locales = [:it, :fr]` will look for `title_it`, `title_fr`, `description_it`, and `description_fr` in the csv file.